### PR TITLE
docs(release): 0.2.0 — SLA documentation, notices, changelog, sliceSla on the handle

### DIFF
--- a/packages/CHANGELOG.md
+++ b/packages/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 0.2.0 — 2026-08-19
+
+SLA (resin) printing lands as a second technology in the same kernel, routed by `printer_technology`.
+
+### Added
+
+- SLA slicing in the WASM kernel: `slicer.sliceSla(stl, params)` on the engine handle,
+  `client.sliceSla` / `client.sliceSlaJob` on the worker client. Results carry per-layer mask segment
+  streams, generated support and pad meshes, `resin_ml` / `time_estimate` stats and `lift_layers`
+  (pad + elevation) — no G-code.
+- The support chain is PrusaSlicer 2.9.6's own, ported verbatim: support-point generator
+  (SupportPointGenerator + SupportIslands), the default support tree, and the real pad geometry. Built
+  against vendored NLopt 2.5.0, Prusa's bundled libigl, SGI glu-libtess, and CGAL headers.
+- `deriveSlaParams(settings)`, `printerTechnology(settings)`, `resinCatalog` / `resinSettingsFor(name)`
+  in `three-slicer/settings`; SLA machine profiles and the resin material catalog in the data files.
+- Typed capability errors instead of silent approximation: `SLA_UNSUPPORTED_HOLLOWING` (hollowing/drain
+  holes), `SLA_UNSUPPORTED_ORGANIC` (organic trees), `SLA_PAD_AROUND_OBJECT_UNSUPPORTED` (zero-elevation
+  pad embedding). `SLA_CAPABILITIES` from `three-slicer/client` is the machine-readable map.
+- Viewer: an SLA printer profile swaps the filament card for the resin card, previews the support/pad
+  meshes with the lifted layer frame, and exports `.sl1` archives — portrait PNG masks (the SL1 family's
+  panel mounting) plus upstream's `config.ini` field set.
+- `<SettingsPanel/>` renders the SLA tabs for an SLA profile — no prop, it follows the settings map.
+- `.3mf` SLA records (manual support points, drain holes) survive import/export round-trip.
+- A runnable SLA example: `node node_modules/three-slicer/engine/examples/sla_headless.mjs`.
+- `THIRD-PARTY-NOTICES.md` documenting the licenses compiled into the shipped kernels.
+
+### Notes
+
+- The multithreaded kernel carries the SLA path too and is pinned byte-identical to the single-threaded
+  one over the same SLA slice.
+- FFF output is unchanged: the golden byte-identical G-code check holds across this release.
+
+Earlier releases (0.1.x) predate this changelog.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,6 +1,6 @@
 # three-slicer
 
-Browser/WASM 3D-printing slicer package derived from [OrcaSlicer](https://github.com/OrcaSlicer/OrcaSlicer). It can slice binary STL files to G-code in Node or the browser, and it also ships React UI pieces for building a browser slicer: a three.js viewport, GPU toolpath preview, and a schema-driven settings panel.
+Browser/WASM 3D-printing slicer package derived from [OrcaSlicer](https://github.com/OrcaSlicer/OrcaSlicer). It can slice binary STL files to G-code in Node or the browser, and it also ships React UI pieces for building a browser slicer: a three.js viewport, GPU toolpath preview, and a schema-driven settings panel. SLA (resin) printers are a second technology in the same kernel — supports and pad from PrusaSlicer's ported chain, previewed in the same viewer, exported as an `.sl1` archive.
 
 The package is published as a single npm package, `three-slicer`, with subpath exports for the engine, viewer, components, worker, and extracted OrcaSlicer data.
 
@@ -23,6 +23,7 @@ The package is published as a single npm package, `three-slicer`, with subpath e
 - Support painting and material painting, plus per-tool filament and purge statistics.
 - 3MF **project** import in the viewer: a slicer-written `.3mf` (OrcaSlicer/BambuStudio save, MakerWorld download) restores its plate layout, project settings, and painted facets — not just the meshes.
 - Extracted data files for custom UIs: config schema, UI tree, toggle rules, invalidation map, and the printer/process/filament catalogs.
+- SLA (resin) slicing: PrusaSlicer 2.9.6's ported support-point generator, support tree and pad, a resin material catalog, and `.sl1` mask export — routed by `printer_technology`, with typed capability errors for what the port does not cover.
 - Automatic multithreaded WASM selection on cross-origin-isolated browser pages.
 
 ## Installation
@@ -399,6 +400,53 @@ worker.postMessage({ cmd: 'erase', facet, hx, hy, hz, cx, cy, cz, radius })
 
 Because a single enum serves both jobs, a support blocker paint and an Extruder 2 paint are the same mark on a facet, and painted materials only take effect with support turned off (the painted multi-material path emits no support). Support painting is unaffected: a support-enabled slice stays on the single-material path.
 
+## SLA (Resin) Slicing
+
+SLA is a second printer technology, not an FFF mode. `printer_technology` in the settings map routes it —
+apply an SLA machine profile from the catalog (`printersByVendor` marks the technology) or set the key
+yourself, then derive SLA params and call the SLA entry:
+
+```js
+import { printerTechnology, deriveSlaParams, resinCatalog, resinSettingsFor } from 'three-slicer/settings'
+
+printerTechnology(settings)                        // 'SLA' or 'FFF'
+const params = deriveSlaParams(settings)           // layers/exposure, display, supports, pad, raster orientation
+
+const result = slicer.sliceSla(stl, params)
+result.stats.sla                                   // true — no G-code; stats carry resin_ml and time_estimate
+result.stats.layers                                // includes the pad + elevation lift below the model
+result.layers[0].paths                             // the same stride-8 segment stream the FFF preview reads
+```
+
+In a worker, `client.sliceSla(stl, params, { onProgress, onLayer })` is the same call over the message
+protocol, and `client.sliceSlaJob(job)` takes the typed job protocol — objects with manual support points,
+drain-hole records and modifier volumes — validated structurally before slicing.
+
+A runnable version ships with the package: `node node_modules/three-slicer/engine/examples/sla_headless.mjs`
+slices a cube with supports and pad, then demonstrates the capability refusal below.
+
+The support chain is PrusaSlicer 2.9.6's own, ported verbatim and compiled into the same WASM kernel: the
+support-point generator, the default support tree, and the real pad geometry. Resin materials follow the
+same catalog pattern as filaments: `resinCatalog` lists them, `resinSettingsFor(name)` is one preset.
+
+**What the kernel cannot do it refuses with a typed code — it never approximates.** A request the port does
+not cover fails with a stable error instead of silently producing something else:
+
+| Code | Refused request |
+| --- | --- |
+| `SLA_UNSUPPORTED_HOLLOWING` | `hollowing_enable` or drain holes — a solid slice answered to a hollow request would be a mislabeled print |
+| `SLA_UNSUPPORTED_ORGANIC` | organic support trees |
+| `SLA_PAD_AROUND_OBJECT_UNSUPPORTED` | zero-elevation pad embedding (`pad_around_object`) |
+
+`SLA_CAPABILITIES` (exported from `three-slicer/client`) is the machine-readable capability map. A `.3mf`
+carrying SLA records survives round-trip regardless: manual support points and drain holes are preserved on
+import and written back on export, even where slicing refuses to consume them.
+
+The viewer follows the technology automatically: an SLA profile swaps the filament card for the resin card,
+hides the FFF-only tools (prime tower, painting brushes), previews the generated support and pad meshes, and
+exports an `.sl1` archive — per-layer PNG masks in the SL1 family's portrait orientation plus upstream's
+`config.ini` — instead of G-code.
+
 ## Worker Usage
 
 Slicing blocks its thread for seconds, so in a browser it belongs in a worker. `three-slicer/client` wraps the
@@ -569,6 +617,7 @@ the layout by hand.
 | --- | --- |
 | `createSlicer()` | Loads the WASM kernel and returns a slicer handle |
 | `slicer.slice(stl, params, callbacks?)` | Slices binary STL input to G-code or streamed layers |
+| `slicer.sliceSla(stl, params, onProgress?)` | SLA slice — layer masks, support/pad meshes, resin stats; typed `error` on a refused capability |
 | `slicer.paintPrepare(stl)` | Prepares painting against a model; returns the facet count |
 | `slicer.paint(args)` | Paints enforcer/blocker data (boolean pair; the state-addressed form is worker-only) |
 | `slicer.paintClear()` | Clears painting data for every state |
@@ -598,6 +647,9 @@ the layout by hand.
 | `machineLimitKeys` | The schema keys the kernel's machine limits are read from |
 | `processPresets()` | Lazy facade over the print (process) preset catalog |
 | `filamentPresets()` | Lazy facade over the material preset catalog |
+| `printerTechnology(settings)` | `'SLA'` or `'FFF'` — what routes a slice to `slice_sla` |
+| `deriveSlaParams(settings)` | Sparse settings → the SLA kernel's params (display, supports, pad, raster) |
+| `resinCatalog` / `resinSettingsFor(name)` | The resin material catalog, and one preset's settings |
 
 ### `three-slicer/toggle`
 
@@ -649,6 +701,9 @@ the layout by hand.
 - Some vector settings are simplified to their first element.
 - Material painting and support cannot currently produce two materials on the same slice: the painted multi-material path emits no support, and one triangle selector serves both brushes.
 - The multi-material prime tower is a real ported wipe tower, but the fallback square ring used when it fails is not.
+- SLA hollowing and drain-hole geometry are refused with `SLA_UNSUPPORTED_HOLLOWING` (the OpenVDB chain is not ported); the records still round-trip through `.3mf`.
+- The `.sl1` export lives in the viewer (its masks need a canvas); there is no headless `.sl1` writer export yet.
+- SLA mask edges are canvas anti-aliasing, not upstream's AGG rasterizer — same geometry, slightly different edge pixels.
 - Multithreaded WASM requires cross-origin isolation.
 - `three` is pinned as a peer dependency because viewer internals depend on the `TransformControls` API shape.
 

--- a/packages/THIRD-PARTY-NOTICES.md
+++ b/packages/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,37 @@
+# Third-party notices
+
+`three-slicer` is licensed AGPL-3.0-or-later (see `LICENSE.txt`). The distributed artifacts — the WASM
+kernels embedded in `engine/src/slicer_core.js` / `slicer_core.mt.js` and the bundled viewer/components —
+contain compiled or bundled code from the following projects. Full license texts ship in the source
+repository at the paths given (the package's `repository` field points there); the kernel's vendored copies
+live under `packages/wasm-core/third_party/deps_src/`.
+
+## Compiled into the WASM kernels
+
+| Component | License | Source of the vendored copy |
+| --- | --- | --- |
+| OrcaSlicer (the FFF slicing code this package is ported from) | AGPL-3.0-or-later | github.com/SoftFever/OrcaSlicer |
+| PrusaSlicer 2.9.6 (the SLA support/pad chain, ported verbatim under `packages/wasm-core/slasupport_port/`) | AGPL-3.0-or-later | github.com/prusa3d/PrusaSlicer |
+| Clipper (Angus Johnson) | BSL-1.0 | `deps_src/clipper/` |
+| Clipper2 | BSL-1.0 | `deps_src/clipper2/` |
+| Boost (header-only use) | BSL-1.0 | headers at build time |
+| Eigen (header-only) | MPL-2.0 | headers at build time |
+| CGAL 6 (header-only use, GMP/MPFR disabled) | GPL-3.0-or-later | headers at build time |
+| libigl (headers; both the Orca-generation copy and Prusa's bundled copy) | MPL-2.0 | `deps_src/libigl/`, `deps_src/libigl_prusa/` |
+| libnest2d (headers) | LGPL-3.0 | `deps_src/libnest2d/` (its `LICENSE.txt`) |
+| NLopt 2.5.0 | LGPL-2.1-or-later for the combined library (`deps_src/nlopt/COPYING`); per-algorithm terms in each `algs/*/COPYRIGHT` — the most restrictive is `algs/luksan` (LGPL-2.1+), most others (e.g. `algs/newuoa`) are MIT-style Powell/MIT notices | `deps_src/nlopt/` |
+| SGI glu-libtess (the GLU tessellator) | SGI Free Software License B 2.0 | `deps_src/glu-libtess/` (header of each source file) |
+| Emscripten runtime (the generated JS glue around the kernels) | MIT | emscripten.org |
+
+## Bundled into the viewer/components builds
+
+| Component | License | Note |
+| --- | --- | --- |
+| fflate (via three.js examples) | MIT | zip/unzip in the 3mf and SL1 codecs |
+
+`three`, `react` and `react-dom` are peer dependencies and are not bundled or redistributed by this package.
+
+The LGPL components (NLopt's luksan directory, libnest2d headers) are compiled into a work distributed under
+AGPL-3.0-or-later, which satisfies their license terms; their complete license texts accompany the source
+repository as noted above. Nothing in this file overrides a component's own license — where this summary and
+a vendored license file disagree, the vendored file is authoritative.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -6,6 +6,8 @@ Reusable React components for the browser slicer. Props-driven — no global sta
 
 An OrcaSlicer-style settings form generated from `three-slicer/data` (schema + UI tree + toggle rules): tab/page/group navigation, mode filter (simple/advanced/expert), search across 923 options, dirty markers with per-option reset, and enable/disable rules evaluation.
 
+The tab set follows the printer profile's technology: a settings map whose `printer_technology` says SLA swaps the FFF tabs for the SLA ones (print/material/printer builders carry the technology in their upstream builder name, which is what the filter reads). No prop needed — change the profile in the shared settings map and the panel follows.
+
 ```bash
 npm i three-slicer     # react is a peer dependency — npm installs it for you
 ```

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -355,6 +355,26 @@ Two consequences worth knowing before you build on this:
 
 Results carry the split: `stats.filament_mm_by_tool` (indexed by tool number, one slot per extruder, sums to `filament_mm`) and `stats.filament_mm_purge` (the prime/wipe tower share, already included in the per-tool figures). In the streamed toolpath, `paths[k+3]` encodes `role + tool * 16` — mask with `& 15` for the role and `>>> 4` for the tool.
 
+## SLA parameters
+
+The table above is the FFF kernel's reader. The SLA entry (`slice_sla`) reads its own parameter set, produced
+by `deriveSlaParams(settings)` — unlike `deriveKernelParams` it always emits every key (49 today), filling
+schema/reference-machine defaults, because the SLA keys are not shared with another technology whose defaults
+could disagree. The groups:
+
+| Group | Keys |
+| --- | --- |
+| Layers and exposure | `layer_height`, `initial_layer_height`, `exposure_time`, `initial_exposure_time`, `faded_layers` |
+| Display (doubles as the bed) | `display_width/height`, `display_pixels_x/y`, `display_orientation` (portrait default), `display_mirror_x/y`, `bed_width/depth` |
+| Archive identity (config.ini) | `printer_model`, `printer_variant`, `printer_settings_id`, `sla_print_settings_id`, `sla_material_settings_id`, `material_print_speed` |
+| Supports (upstream `SupportTreeConfig`) | `supports_enable`, `support_tree_type`, `support_pillar_diameter`, `support_head_*`, `support_points_density_relative`, `support_critical_angle`, `support_max_bridge_length`, `support_max_pillar_link_distance`, `support_base_*`, `support_small_pillar_diameter_percent`, `support_pillar_widening_factor`, `support_max_bridges_on_pillar`, `support_max_weight_on_model`, `support_object_elevation`, `support_pillar_connection_mode`, `support_buildplate_only`, `slice_closing_radius` |
+| Pad (upstream `PadConfig`) | `pad_enable`, `pad_brim_size`, `pad_wall_thickness`, `pad_wall_height`, `pad_wall_slope`, `pad_max_merge_distance`, `pad_around_object` (typed error) |
+| Capability gate | `hollowing_enable` — `true` is refused with `SLA_UNSUPPORTED_HOLLOWING`, never sliced solid |
+
+The result has no G-code: `stats.sla` is `true`, layers carry the same stride-8 segment stream, `support_mesh`
+and `pad_mesh` are triangle soups for the preview, and `stats.lift_layers` (pad + elevation) is what a preview
+must lift the model by.
+
 ## License
 
 AGPL-3.0-or-later (derived from OrcaSlicer). A web app embedding this package must comply with AGPL — including offering its source to network users.

--- a/packages/engine/examples/sla_headless.mjs
+++ b/packages/engine/examples/sla_headless.mjs
@@ -1,0 +1,51 @@
+// three-slicer SLA (resin) headless example: slice a cube with supports + pad through the public API,
+// then show the typed capability refusal — an unsupported request errors, it never approximates.
+//   run: node packages/engine/examples/sla_headless.mjs
+import { createSlicer } from 'three-slicer'
+import { deriveSlaParams, printerTechnology } from 'three-slicer/settings'
+
+// minimal binary-STL writer for a 10mm cube. Winding matters here, unlike the FFF example: the SLA
+//  support generator reads facet normals to find downward faces, so every face is CCW seen from outside.
+function boxSTL() {
+  const vertices = [[-5,-5,0],[5,-5,0],[5,5,0],[-5,5,0],[-5,-5,10],[5,-5,10],[5,5,10],[-5,5,10]]
+  const faces = [[0,2,1],[0,3,2],[4,5,6],[4,6,7],[0,1,5],[0,5,4],[1,2,6],[1,6,5],[2,3,7],[2,7,6],[3,0,4],[3,4,7]]
+  const buf = Buffer.alloc(84 + faces.length * 50)
+  buf.writeUInt32LE(faces.length, 80)
+  faces.forEach((face, i) => {
+    let off = 84 + i * 50 + 12
+    for (const vi of face) for (const v of vertices[vi]) { buf.writeFloatLE(v, off); off += 4 }
+  })
+  return buf
+}
+const cube = boxSTL()
+
+// A sparse settings map, the same shape the UI holds. printer_technology is what routes to slice_sla.
+const settings = {
+  printer_technology: 'SLA',
+  layer_height: 0.05,
+  exposure_time: 7,
+  supports_enable: true,
+  support_object_elevation: 5,
+  pad_enable: true,
+}
+console.log(`technology: ${printerTechnology(settings)}`)
+
+const slicer = await createSlicer()
+const params = deriveSlaParams(settings)     // fills display/support/pad defaults (SL1 reference machine)
+
+// (a) SLA slice — no G-code; masks, meshes and resin stats instead.
+const r = slicer.sliceSla(cube, params)
+if (r.error) { console.error('FAIL', r.error); process.exit(1) }
+console.log(`sla   : layers=${r.stats.layers} (lift=${r.stats.lift_layers}) points=${r.stats.support_points}`
+  + ` pad_layers=${r.stats.pad_layers} resin=${r.stats.resin_ml.toFixed(2)}ml`)
+console.log(`meshes: support=${r.support_mesh.length / 9} tris, pad=${r.pad_mesh.length / 9} tris`)
+
+// (b) the capability gate: hollowing is not ported, so the request is REFUSED with a stable code —
+//     a solid slice answered to a hollow request would be a mislabeled print.
+const refused = slicer.sliceSla(cube, deriveSlaParams({ ...settings, hollowing_enable: true }))
+console.log(`gate  : ${refused.error}`)
+
+if (r.stats.support_points > 0 && r.stats.pad_layers > 0 && /^SLA_UNSUPPORTED_HOLLOWING/.test(refused.error ?? ''))
+  console.log('OK — SLA slices headlessly via the public API')
+else { console.error('FAIL'); process.exit(1) }
+slicer.dispose()

--- a/packages/engine/index.d.ts
+++ b/packages/engine/index.d.ts
@@ -86,6 +86,9 @@ export interface PaintArgs {
 }
 export interface Slicer {
   slice(stl: ArrayBuffer | Uint8Array, params: object | string, cb?: SliceCallbacks): SliceResult
+  /** SLA (resin) slice — no G-code: mask segment streams per layer, support/pad meshes, resin stats.
+   *  Params from deriveSlaParams(); a refused capability (e.g. hollowing) sets `error` to its typed code. */
+  sliceSla(stl: ArrayBuffer | Uint8Array, params: object | string, onProgress?: (done: number, total: number) => void): SliceResult
   paintPrepare(stl: ArrayBuffer | Uint8Array): number
   paint(args: PaintArgs): { enf: number; blk: number }
   paintClear(): void

--- a/packages/engine/index.js
+++ b/packages/engine/index.js
@@ -31,6 +31,12 @@ export async function createSlicer() {
       try { return M.slice(u8(stl), p, onProgress || (() => {})) }
       finally { if (onLayer) M.clear_layer_sink() }
     },
+    // SLA (resin) slice: no G-code — layers carry the mask segment stream, support_mesh/pad_mesh the preview
+    //  soups, stats the resin figures and lift_layers. Same params-object-or-string contract as slice().
+    sliceSla(stl, params, onProgress) {
+      const p = typeof params === 'string' ? params : JSON.stringify(params || {})
+      return M.slice_sla(u8(stl), p, onProgress || (() => {}))
+    },
     paintPrepare(stl) { M.selector_prepare(u8(stl)); return M.selector_facet_count() },
     paint(a) {
       M.selector_paint(a.facet, a.hx, a.hy, a.hz, a.cx, a.cy, a.cz, a.radius, a.enforcer)

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,7 +1,7 @@
 {
   "name": "three-slicer",
-  "version": "0.1.7",
-  "description": "Browser/WASM 3D-printing slicer reverse-engineered from OrcaSlicer: slicing engine (Arachne walls, tree/grid supports, multi-material), React viewer with GPU toolpath preview, and schema-driven settings UI.",
+  "version": "0.2.0",
+  "description": "Browser/WASM 3D-printing slicer reverse-engineered from OrcaSlicer: slicing engine (Arachne walls, tree/grid supports, multi-material), SLA resin slicing with PrusaSlicer's ported support/pad chain and .sl1 export, React viewer with GPU toolpath preview, and schema-driven settings UI.",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "exports": {
@@ -96,6 +96,8 @@
     "!data/config-schema-builddump.json",
     "!data/**/.omc",
     "README.md",
+    "CHANGELOG.md",
+    "THIRD-PARTY-NOTICES.md",
     "LICENSE.txt"
   ],
   "repository": {
@@ -108,6 +110,10 @@
     "3d-printing",
     "slicer",
     "gcode",
+    "sla",
+    "resin",
+    "sl1",
+    "msla",
     "stl",
     "wasm",
     "orcaslicer",

--- a/packages/types/client.d.ts
+++ b/packages/types/client.d.ts
@@ -4,7 +4,8 @@ import type { BrushArgs, PaintState, PaintTool } from './worker.d.ts'
 import type { SlaJob } from './sla.d.ts'
 
 export type { BrushArgs, PaintState, PaintTool }
-export { SLA_CAPABILITIES, SLA_JOB_VERSION, SlaRequestError } from './sla.d.ts'
+// Value re-exports must not name the .d.ts directly (TS2846) — the .js specifier resolves to sla.d.ts.
+export { SLA_CAPABILITIES, SLA_JOB_VERSION, SlaRequestError } from './sla.js'
 export type * from './sla.d.ts'
 
 export interface ClientSliceCallbacks {

--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -66,7 +66,10 @@ Every panel can be switched off, and the values the component owns can be seeded
   `emptyHint`, `status`, `printerCard`, `filamentCard`, `resinCard`, `objectList`, `previewControls`, `processCard`,
   `sliceBar`. Which of `filamentCard`/`resinCard` renders follows the printer profile's technology: a profile whose
   `printer_technology` says SLA swaps the filament card (and the prime tower, and the painting brushes) for the
-  resin card, and slicing routes to the pure-JS contour slicer with an `.sl1` export instead of G-code.
+  resin card, and slicing routes to the kernel's `slice_sla` — PrusaSlicer's ported support/pad chain — with an
+  `.sl1` export instead of G-code (portrait masks, like every SL1-family machine). The preview lifts the model by
+  `stats.lift_layers` (pad + elevation), and a request the port does not cover (hollowing, organic trees,
+  `pad_around_object`) surfaces as a typed error instead of a wrong print.
 - **`gcode`** — G-code text drawn on the selected plate instead of a slice result. `parseGcode` recovers roles from
   `;TYPE:` (OrcaSlicer/PrusaSlicer/Cura), from `;_EXTRUSION_ROLE:` tags and from this kernel's own feature comments;
   bead width comes from `;WIDTH:` or, absent that, from E. What the file never states cannot be recovered: an

--- a/web/README.md
+++ b/web/README.md
@@ -73,7 +73,8 @@ Regenerate: `python3 web/extract_all.py` (paths are derived from `__file__` — 
   the final truth about which options exist and their types and defaults.
 - The **automatic value-correction dialog rules** in `update_print_fff_config` (ConfigManipulation.cpp) — e.g. forcing wall_loops=1 when spiral
   mode is on — are not toggles, so they are absent from this JSON. They must be translated by hand.
-- The SLA family was extracted but not reviewed.
+- The SLA family is extracted and now consumed: the SLA tabs render in the settings panel and `deriveSlaParams`
+  reads the display/support/pad keys (see `packages/engine/README.md`, "SLA parameters").
 - The ui-tree <-> schema cross-check found 2 dangling references: `spaghetti_detector` (commented out at PrintConfig.cpp:4020 while
   TabPrinter still references it) and `pad_edge_radius` (SLA legacy, no definition). A web implementation can simply
   skip these two keys.


### PR DESCRIPTION
## What

Release documentation for 0.2.0 (the SLA release), plus two things the docs pass surfaced that were code, not prose:

- `slicer.sliceSla(stl, params)` on the public engine handle — the SLA entry existed only on the raw wasm module, so the documented API had no way to reach it. Typed on the `Slicer` interface; a runnable `engine/examples/sla_headless.mjs` ships in the tarball.
- fix(types): `client.d.ts` re-exported values from `'./sla.d.ts'`, which tsc rejects (TS2846) — the consumer-side type check in `pack_check` was failing on it. Now `'./sla.js'`.

Documentation:

- Package README: SLA section (routing, capability-code table, `.sl1` export), features/intro, API rows, known limits.
- Engine README: the 49-key `deriveSlaParams` surface by group, outside the generated markers.
- Viewer README: corrected a stale claim (SLA routed "to the pure-JS contour slicer" — it is the kernel's ported chain since the wasm port).
- Components README: the panel follows `printer_technology`.
- `CHANGELOG.md` starting at 0.2.0 and `THIRD-PARTY-NOTICES.md` (the wasm embeds LGPL/MPL/BSL/GPL/SGI-B code; the tarball carried only the AGPL text) — both added to `files`.
- package.json: description/keywords cover SLA/resin/SL1 (the 0.2.0 version bump itself was made by hand before this branch).

## Verification

- `npm test` exit 0.
- `bash packages/pack_check.sh` exit 0 — including the consumer `tsc --noEmit` that failed before the types fix — and the tarball listing shows `CHANGELOG.md`, `THIRD-PARTY-NOTICES.md`, `engine/examples/sla_headless.mjs`.
- `node packages/engine/examples/sla_headless.mjs` runs green (supports + pad + typed refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
