### PR TITLE
fix: sync package-lock with the 0.2.0 bump (npm ci failure)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "packages": {
       "name": "three-slicer",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "typescript": "^5.6.0",
@@ -1799,7 +1799,7 @@
         "react-dom": "^18.3.1",
         "react-router": "^7.0.0",
         "three": "^0.160.0",
-        "three-slicer": "^0.1.1"
+        "three-slicer": "^0.2.0"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",

--- a/web/viewer/package.json
+++ b/web/viewer/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^18.3.1",
     "react-router": "^7.0.0",
     "three": "^0.160.0",
-    "three-slicer": "^0.1.1"
+    "three-slicer": "^0.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",


### PR DESCRIPTION
## What

The Docker build failed at `npm ci`: `Missing: three-slicer@0.1.7 from lock file`.

Two layers to it:

1. The 0.2.0 version bump never regenerated `package-lock.json`, which still recorded the workspace as `three-slicer@0.1.7` — `npm ci` refuses on any package.json/lock mismatch.
2. Regenerating the lock alone silently did the wrong thing: `web/viewer` depended on `three-slicer: ^0.1.1`, and under 0.x semver that range excludes 0.2.0 — npm resolved `three-slicer@0.1.7` from the npm registry into `web/viewer/node_modules` instead of linking the workspace. The demo would have built against the published 0.1.7, not the local sources.

Fix: `web/viewer` now depends on `^0.2.0`, and the regenerated lock records the workspace link (`"resolved": "packages", "link": true`). The lock diff is two lines plus the range.

## Verification

- `npm ci` exit 0 (clean reinstall from the lock)
- `npm run build` exit 0, `npm test` exit 0 after the clean install — the same sequence the Dockerfile runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)