### PR TITLE
chore: bump three-slicer to 0.2.1

### DIFF
--- a/packages/package.json
+++ b/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-slicer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Browser/WASM 3D-printing slicer reverse-engineered from OrcaSlicer: slicing engine (Arachne walls, tree/grid supports, multi-material), SLA resin slicing with PrusaSlicer's ported support/pad chain and .sl1 export, React viewer with GPU toolpath preview, and schema-driven settings UI.",
   "license": "AGPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
## Summary
- `three-slicer` 0.2.0 -> 0.2.1 — releases the SLA layer-parallel/raster perf work already merged in #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)