### PR TITLE
docs: README, landing and about page for the 0.3.0 split

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,24 @@ Resin printing is a second technology in the same kernel, routed by `printer_tec
 ## Links
 
 - Demo: [slicer.kimgh06.com](https://slicer.kimgh06.com/)
-- npm package: [three-slicer](https://www.npmjs.com/package/three-slicer)
-- Source: [kimgh06/Web_Three_Slicer](https://github.com/kimgh06/Web_Three_Slicer)
+- npm packages: [three-slicer](https://www.npmjs.com/package/three-slicer) (AGPL, slicing) · [three-slicer-viewer](https://www.npmjs.com/package/three-slicer-viewer) (MIT, viewer)
+- Source: [kimgh06/Web_Three_Slicer](https://github.com/kimgh06/Web_Three_Slicer) · viewer mirror [kimgh06/three-slicer-viewer](https://github.com/kimgh06/three-slicer-viewer)
 - Integration example specs: [examples/DEMOS.md](examples/DEMOS.md)
 - Community: [questions, ideas, or a print you sliced with it](https://github.com/kimgh06/Web_Three_Slicer/discussions) — bug reports go to [Issues](https://github.com/kimgh06/Web_Three_Slicer/issues)
 
-## Package (`packages/`, npm workspace)
+## Packages (npm workspace)
 
-| Package | What it is |
-|---|---|
-| `three-slicer` | WASM slicing kernel SDK — FFF batch/streaming slice, SLA slice, worker protocol, settings mapping. Headless-capable (Node or browser), **no three.js dependency** |
-| `three-slicer/data` | Extracted OrcaSlicer metadata: config schema, UI tree, toggle rules, invalidation map, and the printer/process/filament/resin preset catalogs |
-| `three-slicer/components` | React `<SettingsPanel/>` — schema-driven settings form, props-only, Shadow DOM isolated |
-| `three-slicer/viewer` | React `<Viewport/>` — three.js scene, model import, worker slicing, GPU volumetric toolpath preview, SLA support/pad preview and `.sl1` import/export, Shadow DOM isolated |
+Two packages, released as a locked pair (same version; `three-slicer` pins `three-slicer-viewer` exactly).
 
-Quick taste:
+| Package | License | What it is |
+|---|---|---|
+| `three-slicer` | AGPL | WASM slicing kernel SDK — FFF batch/streaming slice, SLA slice, worker protocol, settings mapping. Headless-capable (Node or browser), **no three.js dependency** |
+| `three-slicer/data` | AGPL | Extracted OrcaSlicer metadata: config schema, UI tree, toggle rules, invalidation map, and the printer/process/filament/resin preset catalogs |
+| `three-slicer/viewer`, `three-slicer/components` | AGPL | The viewer and settings panel below with the kernel and the vendor presets plugged in — thin wrappers over `three-slicer-viewer` |
+| `three-slicer-viewer` | MIT | React `<Viewport/>` — three.js scene, model import, GPU volumetric toolpath preview, G-code parsing, SLA preview and `.sl1` import/export, Shadow DOM isolated. Displays and exports; slicing is a prop |
+| `three-slicer-viewer/components` | MIT | React `<SettingsPanel/>` — schema-driven settings form, props-only, Shadow DOM isolated |
+
+Quick taste (slicer included — AGPL):
 
 ```jsx
 import { useState } from 'react'
@@ -39,11 +42,19 @@ function App() {
 }
 ```
 
+Viewer only (MIT — model and G-code preview, no slicing, no AGPL in the tree):
+
+```jsx
+import Viewport from 'three-slicer-viewer'
+<Viewport files={files} settings={settings} setSettings={setSettings} />
+```
+
 Headless (no UI): `const s = await createSlicer(); s.slice(stl, params)`, or `s.sliceSla(stl, slaParams)` for resin — see [`packages/README.md`](packages/README.md).
 
 ## Repository layout
 
-- **`packages/`** — published npm package `three-slicer`, extracted data, React components/viewer, and WASM kernel sources. Self-contained: builds, tests, and runs without `slicers/`.
+- **`packages/`** — the npm package `three-slicer` (AGPL): kernel SDK, extracted data, WASM kernel sources, and the wrappers that plug the kernel into the viewer. Self-contained: builds, tests, and runs without `slicers/`.
+- **`packages-mit/`** — the npm package `three-slicer-viewer` (MIT): the viewer, the settings panel, G-code parsing and the toolpath renderer. Mirrored to its own repository on every release.
 - **`web/`** — demo viewer app that consumes `three-slicer` through the workspace package name.
 - **`slicers/`** — untracked reference clones (each its own git remote): upstream OrcaSlicer at `slicers/slicer` (the extraction/porting source) and PrusaSlicer at `slicers/PrusaSlicer` (comparison only).
 
@@ -54,16 +65,21 @@ cd web && make dev
 # full gate: kernel invariants (FFF + SLA), the generated param table, the viewer's pure modules
 npm test
 
-# tarball independence gate (packs three-slicer, builds Vite+Next consumers outside the repo)
+# tarball independence gate (packs both packages, builds Node/Vite/Next consumers and a viewer-only one outside the repo)
 bash packages/pack_check.sh
+
+# release both packages in order (viewer first), sync the mirror, tag — DRY=1 to rehearse
+make bump V=x.y.z && make publish
 ```
 
 Development docs (demo app, stage-by-stage log, reverse-engineering guide, format specs): [`web/README.md`](web/README.md), [`web/HISTORY.md`](web/HISTORY.md), [`web/GUIDE.md`](web/GUIDE.md), [`web/SPECS.md`](web/SPECS.md).
 
 ## License
 
-`three-slicer` is AGPL-3.0-or-later (see [`LICENSE.txt`](LICENSE.txt)) — derived from OrcaSlicer. The viewer, the settings
-form, G-code parsing and toolpath rendering are published separately as [`three-slicer-viewer`](packages-mit/) under MIT,
-which contains no upstream code (`packages/PROVENANCE.md`); only slicing itself, and the vendor presets, are AGPL.
+`three-slicer` is AGPL-3.0-or-later ([`LICENSE.txt`](LICENSE.txt)) — derived from OrcaSlicer. AGPL extends to network
+use: a web service embedding it must offer its source to its users.
 
-AGPL-3.0-or-later — derived from OrcaSlicer. Note that AGPL extends to network use: a web service embedding these packages must offer its source to its users.
+`three-slicer-viewer` ([`packages-mit/`](packages-mit/)) is MIT: the viewer, the settings form, G-code parsing and
+toolpath rendering contain no upstream code ([`packages/PROVENANCE.md`](packages/PROVENANCE.md)) and can go into
+closed-source products. Only slicing itself, and the vendor presets, are AGPL. Which files may carry which license,
+and why, is [`packages/PROVENANCE.md`](packages/PROVENANCE.md); a license-boundary test enforces the split.

--- a/packages-mit/package.json
+++ b/packages-mit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "three-slicer-viewer",
   "version": "0.3.0",
-  "description": "The three-slicer viewer without the slicer — model loading, G-code parsing, GPU toolpath rendering and the settings transforms, under MIT. Plug a slicer in through the `slicer` prop.",
+  "description": "The three-slicer viewer without the slicer \u2014 model loading, G-code parsing, GPU toolpath rendering and the settings transforms, under MIT. Plug a slicer in through the `slicer` prop.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -55,11 +55,35 @@
   ],
   "keywords": [
     "3d-printing",
+    "3d-printer",
+    "viewer",
     "gcode",
+    "gcode-viewer",
     "toolpath",
+    "stl",
+    "obj",
+    "3mf",
+    "amf",
+    "ply",
+    "sl1",
+    "sla",
+    "resin",
     "three",
-    "viewer"
+    "three.js",
+    "threejs",
+    "react",
+    "webgl",
+    "model-viewer",
+    "three-slicer"
   ],
+  "homepage": "https://slicer.kimgh06.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kimgh06/three-slicer-viewer.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kimgh06/three-slicer-viewer/issues"
+  },
   "peerDependencies": {
     "three": "^0.160.0",
     "react": ">=18",

--- a/web/viewer/about/index.html
+++ b/web/viewer/about/index.html
@@ -83,7 +83,7 @@
         <li><b>WebAssembly</b><small>the OrcaSlicer kernel, compiled</small></li>
         <li><b>No upload</b><small>slicing runs in your tab</small></li>
         <li><b>976</b><small>OrcaSlicer options</small></li>
-        <li><b>AGPL-3.0</b><small>or later</small></li>
+        <li><b>AGPL + MIT</b><small>slicer · viewer</small></li>
       </ul>
 
       <h2>Why it exists</h2>
@@ -167,6 +167,16 @@
         the same license. If the AGPL is a problem for your product, it is a problem before you start
         rather than after, so it is worth reading first.
       </p>
+      <p>
+        The viewer is the exception. Since 0.3.0 the display half — model loading, G-code parsing, the
+        GPU toolpath preview and the settings panel — is published on its own as
+        <a href="https://www.npmjs.com/package/three-slicer-viewer" rel="noopener">three-slicer-viewer</a>
+        under <strong>MIT</strong>. It contains no OrcaSlicer or PrusaSlicer code (the provenance of every
+        file is recorded in the repository), so it can go into a closed-source product; only slicing itself,
+        and the vendor presets, stay AGPL. Which files may carry which license, and why, is
+        <a href="https://github.com/kimgh06/Web_Three_Slicer/blob/main/packages/PROVENANCE.md" rel="noopener">PROVENANCE.md</a>,
+        and a license-boundary test enforces the split on every build.
+      </p>
 
       <h2>Who maintains it</h2>
       <p>
@@ -189,7 +199,7 @@
       </p>
 
       <footer>
-        <span>Three Slicer · AGPL-3.0-or-later</span>
+        <span>Three Slicer · AGPL-3.0-or-later · viewer MIT</span>
         <a href="/">Home</a>
         <a href="/slice">Slicer</a>
         <a href="/demos">Demos</a>

--- a/web/viewer/index.html
+++ b/web/viewer/index.html
@@ -63,8 +63,33 @@
           ],
           "sameAs": [
             "https://github.com/kimgh06/Web_Three_Slicer",
-            "https://www.npmjs.com/package/three-slicer"
+            "https://www.npmjs.com/package/three-slicer",
+            "https://www.npmjs.com/package/three-slicer-viewer"
           ]
+        },
+        {
+          "@type": "SoftwareSourceCode",
+          "@id": "https://www.npmjs.com/package/three-slicer#package",
+          "name": "three-slicer",
+          "url": "https://www.npmjs.com/package/three-slicer",
+          "codeRepository": "https://github.com/kimgh06/Web_Three_Slicer",
+          "programmingLanguage": ["JavaScript", "C++"],
+          "runtimePlatform": ["Node.js", "Web browser (WebAssembly)"],
+          "license": "https://www.gnu.org/licenses/agpl-3.0.html",
+          "description": "The slicing kernel as an npm package: FFF and SLA slicing in Node or the browser, a worker protocol, OrcaSlicer settings mapping and preset catalogs.",
+          "targetProduct": { "@id": "https://slicer.kimgh06.com/#app" }
+        },
+        {
+          "@type": "SoftwareSourceCode",
+          "@id": "https://www.npmjs.com/package/three-slicer-viewer#package",
+          "name": "three-slicer-viewer",
+          "url": "https://www.npmjs.com/package/three-slicer-viewer",
+          "codeRepository": "https://github.com/kimgh06/three-slicer-viewer",
+          "programmingLanguage": "JavaScript",
+          "runtimePlatform": "Web browser",
+          "license": "https://opensource.org/license/mit",
+          "description": "MIT React + three.js viewer for 3D printing: STL, OBJ, 3MF, AMF and PLY loading, G-code parsing, GPU toolpath preview and a schema-driven settings panel. No slicer and no AGPL code; slicing is plugged in through a prop.",
+          "targetProduct": { "@id": "https://slicer.kimgh06.com/#app" }
         },
         {
           "@type": "TechArticle",
@@ -97,7 +122,7 @@
             {
               "@type": "Question",
               "name": "Can I use the slicer in my own site or app?",
-              "acceptedAnswer": { "@type": "Answer", "text": "Yes. The same engine is published to npm as three-slicer under AGPL-3.0-or-later: a headless slicing kernel for Node or the browser, plus an optional React viewer and settings panel." }
+              "acceptedAnswer": { "@type": "Answer", "text": "Yes, as two npm packages. three-slicer (AGPL-3.0-or-later) is the slicing kernel for Node or the browser. three-slicer-viewer (MIT) is the React viewer and settings panel on their own — model and G-code preview with no slicing and no AGPL code, usable in closed-source products. Installing three-slicer gives you both." }
             }
           ]
         }
@@ -162,10 +187,13 @@
       </p>
       <h3>Can I use the slicer in my own site or app?</h3>
       <p>
-        Yes. The same engine is published to npm as
-        <a href="https://www.npmjs.com/package/three-slicer">three-slicer</a> under
-        AGPL-3.0-or-later — a headless slicing kernel for Node or the browser, plus an optional React
-        viewer and settings panel. The <a href="/demos">integration demos</a> show it embedded in an
+        Yes, as two npm packages.
+        <a href="https://www.npmjs.com/package/three-slicer">three-slicer</a> (AGPL-3.0-or-later) is the
+        slicing kernel for Node or the browser.
+        <a href="https://www.npmjs.com/package/three-slicer-viewer">three-slicer-viewer</a> (MIT) is the React
+        viewer and settings panel on their own — model and G-code preview with no slicing and no AGPL code,
+        usable in closed-source products. Installing three-slicer gives you both. The
+        <a href="/demos">integration demos</a> show it embedded in an
         instant-quote form, a printer showcase and a CAD page, and the source is on
         <a href="https://github.com/kimgh06/Web_Three_Slicer">GitHub</a>.
       </p>

--- a/web/viewer/public/sitemap.xml
+++ b/web/viewer/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://slicer.kimgh06.com/</loc>
-    <lastmod>2026-08-16</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
@@ -17,7 +17,7 @@
   </url>
   <url>
     <loc>https://slicer.kimgh06.com/about</loc>
-    <lastmod>2026-09-01</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <priority>0.7</priority>
   </url>
   <url>

--- a/web/viewer/src/Landing.jsx
+++ b/web/viewer/src/Landing.jsx
@@ -55,14 +55,15 @@ const FAQ = [
   ['Is it based on a real slicer?',
    'Yes. The kernel is a port of OrcaSlicer, which is itself a PrusaSlicer/Slic3r descendant. Arachne wall generation, tree supports, multi-material segmentation and the prime tower are ported from that source rather than reimplemented, and the resin support-point generator, support tree and pad are ported from PrusaSlicer 2.9.6.'],
   ['Can I use the slicer in my own site or app?',
-   'Yes. The same engine is published to npm as three-slicer under AGPL-3.0-or-later: a headless slicing kernel for Node or the browser, plus an optional React viewer and settings panel.'],
+   'Yes, as two npm packages. three-slicer (AGPL-3.0-or-later) is the slicing kernel for Node or the browser. three-slicer-viewer (MIT) is the React viewer and settings panel on their own — model and G-code preview with no slicing and no AGPL code, usable in closed-source products. Installing three-slicer gives you both.'],
 ]
 
 const ROUTES = [
   ['Engine', 'three-slicer', 'Slice a binary STL into G-code, or into SLA layer masks, in Node or the browser'],
   ['Settings', 'three-slicer/settings', 'Convert an OrcaSlicer settings map into kernel parameters'],
-  ['Viewer', 'three-slicer/viewer', 'React 3D viewer: model loading, worker slicing, toolpath preview'],
+  ['Viewer', 'three-slicer/viewer', 'React 3D viewer with the kernel plugged in: model loading, worker slicing, toolpath preview'],
   ['Components', 'three-slicer/components', `React SettingsPanel driven by the ${OPTION_COUNT}-option schema`],
+  ['Viewer (MIT)', 'three-slicer-viewer', 'The same viewer and settings panel without the slicer — model and G-code preview, no AGPL'],
   ['Data', 'three-slicer/data', 'config schema, UI tree, toggle rules, printer / process / filament catalogs'],
   ['Worker', 'three-slicer/worker', 'Layer streaming off the browser main thread'],
 ]
@@ -251,11 +252,12 @@ export default function Landing() {
         <section className="lp-section" aria-labelledby="install-title">
           <div className="lp-section-head">
             <h2 id="install-title">Install</h2>
-            <p>Use the headless engine on its own, or add the React viewer and settings UI on top.</p>
+            <p>Slicing included (AGPL), or the viewer alone (MIT). The React viewer needs <code>react</code>,
+              <code>react-dom</code> and <code>three</code> as peers; the headless engine needs nothing.</p>
           </div>
           <div className="lp-code-grid">
             <pre><code>npm i three-slicer</code></pre>
-            <pre><code>npm i three-slicer react react-dom three</code></pre>
+            <pre><code>npm i three-slicer-viewer</code></pre>
           </div>
         </section>
 
@@ -325,7 +327,7 @@ export default function Landing() {
         </section>
 
         <section className="lp-section lp-license" aria-label="License">
-          <p>AGPL-3.0-or-later · based on OrcaSlicer · runs in the browser or Node with no server</p>
+          <p>three-slicer AGPL-3.0-or-later · three-slicer-viewer MIT · based on OrcaSlicer · runs in the browser or Node with no server</p>
           <Link to="/slice">Start slicing</Link>
           <Link to="/demos">See the demos</Link>
           <a href="/docs/orcaslicer-webassembly-port">How the port works</a>


### PR DESCRIPTION
Follow-up to the 0.3.0 release: the root README and the site still described one package.

## What changes

- **README**: package table with a license column (`three-slicer` AGPL, `three-slicer-viewer` MIT, the `/viewer` and `/components` wrappers), a viewer-only quick taste, `packages-mit/` in the repository layout, `make bump && make publish` in the commands, and the two duplicated License paragraphs folded into one.
- **Landing** (`Landing.jsx` + `index.html`): the "Can I use it in my app" FAQ answer names both packages (JSON-LD kept word-for-word with the rendered page); Install is two commands — `npm i three-slicer` (slicing included) and `npm i three-slicer-viewer` (viewer alone) — with the peer note as text; a `three-slicer-viewer` card under Use It As; the footer license line.
- **SEO**: `SoftwareSourceCode` nodes for both npm packages in the JSON-LD graph (repository, license, runtime, `targetProduct`), `sameAs` link to the viewer package, sitemap `lastmod` for `/` and `/about`.
- **About page**: License section gets the MIT viewer paragraph (with the PROVENANCE link), the stats badge and footer say `AGPL + MIT`.
- **`packages-mit/package.json`**: `keywords` 5 → 21, `homepage`, `repository` (the mirror repo), `bugs`. Applies from the next publish.

## Verification

- `vite build` passes; `dist/index.html` and `dist/about/index.html` carry the new copy.
- JSON-LD parses (6 nodes); the 4 FAQ answers are byte-equal between `Landing.jsx` and `index.html`.
- `test_readme_quickstart`, `test_version_lockstep`, `test_license_boundary` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)