### PR TITLE
fix(web): pin the demo app to the workspace versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # three-slicer-viewer exactly, so the viewer must reach the registry first or three-slicer@x.y.z cannot be
 # installed at all, and the MIT mirror must be pushed after so it shows the code that was published.
 #
-#   make bump V=0.3.0        set both packages and the pin, then check the lockstep
+#   make bump V=0.3.0        set both packages, the pin and the demo app's pins, then check the lockstep
 #   make publish             preflight (clean tree on a pushed main, tests, tarball check) -> publish
 #                            viewer -> publish three-slicer -> sync the mirror -> tag vX.Y.Z and push it
 #   make publish DRY=1       the same with `npm publish --dry-run`, no git checks, no tag, no mirror push
@@ -14,13 +14,14 @@ NPM_PUBLISH   := npm publish $(if $(filter 1,$(DRY)),--dry-run,)
 
 .PHONY: bump preflight publish
 
-bump:  ## set three-slicer, three-slicer-viewer and the pin to V=x.y.z
+bump:  ## set three-slicer, three-slicer-viewer, the pin and the demo app's pins to V=x.y.z
 	@test -n "$(V)" || { echo "usage: make bump V=0.3.0"; exit 1; }
 	@node -e ' \
 	  const fs = require("fs"); \
 	  const edit = (path, fn) => { const pkg = JSON.parse(fs.readFileSync(path, "utf8")); fn(pkg); fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n") }; \
 	  edit("packages-mit/package.json", p => { p.version = "$(V)" }); \
 	  edit("packages/package.json", p => { p.version = "$(V)"; p.dependencies["three-slicer-viewer"] = "$(V)" }); \
+	  edit("web/viewer/package.json", p => { p.dependencies["three-slicer"] = "$(V)"; p.dependencies["three-slicer-viewer"] = "$(V)" }); \
 	  console.log("bumped both packages and the pin to $(V)")'
 	@npm i --package-lock-only --no-audit --no-fund >/dev/null
 	@node packages-mit/test_version_lockstep.mjs >/dev/null && echo "lockstep ok"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1834,56 +1834,12 @@
         "react-dom": "^18.3.1",
         "react-router": "^7.0.0",
         "three": "^0.160.0",
-        "three-slicer": "^0.2.0",
-        "three-slicer-viewer": "0.2.5"
+        "three-slicer": "0.3.0",
+        "three-slicer-viewer": "0.3.0"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
         "vite": "^5.4.11"
-      }
-    },
-    "web/viewer/node_modules/three-slicer": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/three-slicer/-/three-slicer-0.2.5.tgz",
-      "integrity": "sha512-EMSgavuudKnZ3IGKs6q6Lg1M5WgWVKhcanSSuSLgABaNZIOlP86rjcHd+usML8wFw6LMHG/c5wHbWS7qzwpGtQ==",
-      "license": "AGPL-3.0-or-later",
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18",
-        "three": "^0.160.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "three": {
-          "optional": true
-        }
-      }
-    },
-    "web/viewer/node_modules/three-slicer-viewer": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/three-slicer-viewer/-/three-slicer-viewer-0.2.5.tgz",
-      "integrity": "sha512-sq7xFEqfZejnirNuDEb+pHGzsXHlMDzYupvfmDXa1TN0e5Se6wWA3PQjFL+lpm43vh0JD3PiCy4PP4xqSrZUjQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18",
-        "three": "^0.160.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "three": {
-          "optional": true
-        }
       }
     }
   }

--- a/packages-mit/test_version_lockstep.mjs
+++ b/packages-mit/test_version_lockstep.mjs
@@ -47,6 +47,18 @@ if (typeof declared === 'string') {
     `${declared} vs ${permissive.version}`)
 }
 
+console.log('\n[lockstep: the demo app pins the workspace versions]')
+// web/viewer is a workspace member, but a range it declares is still a RANGE: when the pair moved to 0.3.0
+//  and the app still said ^0.2.0, npm quietly fetched 0.2.5 from the registry into web/viewer/node_modules
+//  and the docker build failed on an export that 0.2.5 does not have. An exact pin cannot drift that way.
+const webPath = join(here, '..', 'web', 'viewer', 'package.json')
+if (existsSync(webPath)) {
+  const web = JSON.parse(readFileSync(webPath, 'utf8'))
+  for (const name of [agpl.name, permissive.name])
+    check(`web/viewer pins ${name} at ${permissive.version}`, web.dependencies?.[name] === permissive.version,
+      String(web.dependencies?.[name]))
+}
+
 console.log('\n[lockstep: the licenses are what the split assumed]')
 check(`${permissive.name} is permissively licensed`, permissive.license === 'MIT', permissive.license)
 check(`${agpl.name} is still AGPL`, /^AGPL-3\.0/.test(agpl.license || ''), agpl.license)

--- a/web/viewer/package.json
+++ b/web/viewer/package.json
@@ -15,8 +15,8 @@
     "react-dom": "^18.3.1",
     "react-router": "^7.0.0",
     "three": "^0.160.0",
-    "three-slicer": "^0.2.0",
-    "three-slicer-viewer": "0.2.5"
+    "three-slicer": "0.3.0",
+    "three-slicer-viewer": "0.3.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",


### PR DESCRIPTION
`make up` failed after the 0.3.0 release:

```
src/Prepare.jsx (3:9): "makeSlicerWorker" is not exported by "node_modules/three-slicer/engine/src/client.js"
```

## Cause

`web/viewer/package.json` declared `three-slicer: ^0.2.0` and `three-slicer-viewer: 0.2.5`. Once the pair moved to 0.3.0 neither range matched the workspace packages, so npm fetched 0.2.5 from the registry into `web/viewer/node_modules/` (the lockfile recorded `three-slicer-0.2.5.tgz`), and 0.2.5's `client.js` has no `makeSlicerWorker`.

## Fix

- `web/viewer/package.json`: exact `0.3.0` pins for both packages.
- `make bump`: also writes the demo app's two pins.
- `test_version_lockstep.mjs`: checks the demo app's pins equal the version, so this drift fails the test instead of silently installing from the registry.
- `package-lock.json`: the nested 0.2.5 entries are gone; `web/viewer` resolves to the workspace links.

## Verification

- After `npm i`: no `web/viewer/node_modules/three-slicer`, `node_modules/three-slicer -> ../packages`, `vite build` of `web/viewer` passes.
- Planting `^0.2.0` back makes the lockstep test fail naming `web/viewer`; restored, it passes.
- Not run here: `make up` itself (no docker daemon on this machine) — the failing step (`npm ci && npm run build`) was reproduced locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)